### PR TITLE
Simple code cleanup

### DIFF
--- a/app/src/main/java/net/typeblog/shelter/services/FileShuttleService.java
+++ b/app/src/main/java/net/typeblog/shelter/services/FileShuttleService.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,9 +47,9 @@ public class FileShuttleService extends Service {
         }
 
         @Override
-        public List<Map> loadFiles(String path) {
+        public List<Map<String, Serializable>> loadFiles(String path) {
             resetSuicideTask();
-            ArrayList<Map> ret = new ArrayList<>();
+            ArrayList<Map<String, Serializable>> ret = new ArrayList<>();
             File f = new File(resolvePath(path));
             if (f.listFiles() != null) {
                 for (File child : f.listFiles()) {
@@ -59,10 +60,10 @@ public class FileShuttleService extends Service {
         }
 
         @Override
-        public Map loadFileMeta(String path) {
+        public Map<String, Serializable> loadFileMeta(String path) {
             resetSuicideTask();
             File f = new File(resolvePath(path));
-            HashMap<String, Object> map = new HashMap<>();
+            HashMap<String, Serializable> map = new HashMap<>();
             map.put(DocumentsContract.Document.COLUMN_DOCUMENT_ID, f.getAbsolutePath());
             map.put(DocumentsContract.Document.COLUMN_DISPLAY_NAME, f.getName());
             map.put(DocumentsContract.Document.COLUMN_SIZE, f.length());

--- a/app/src/main/java/net/typeblog/shelter/services/FreezeService.java
+++ b/app/src/main/java/net/typeblog/shelter/services/FreezeService.java
@@ -50,10 +50,10 @@ public class FreezeService extends Service {
     }
 
     // An app being inactive for this amount of time will be frozen
-    private static long APP_INACTIVE_TIMEOUT = 1000;
+    private static final long APP_INACTIVE_TIMEOUT = 1000;
 
     // Notification ID
-    private static int NOTIFICATION_ID = 0xe49c0;
+    private static final int NOTIFICATION_ID = 0xe49c0;
 
     // The actual receiver of the screen-off event
     private BroadcastReceiver mLockReceiver = new BroadcastReceiver() {

--- a/app/src/main/java/net/typeblog/shelter/ui/AppListAdapter.java
+++ b/app/src/main/java/net/typeblog/shelter/ui/AppListAdapter.java
@@ -325,7 +325,7 @@ public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHold
         if (mLabelDisabled == null) {
             mLabelDisabled = viewGroup.getContext().getString(R.string.list_item_disabled);
         }
-        LayoutInflater inflater = viewGroup.getContext().getSystemService(LayoutInflater.class);
+        LayoutInflater inflater = LayoutInflater.from(viewGroup.getContext());
         View view = inflater.inflate(R.layout.app_list_item, viewGroup, false);
         ViewHolder vh = new ViewHolder(view);
         vh.setIndex(i);

--- a/app/src/main/java/net/typeblog/shelter/ui/AppListAdapter.java
+++ b/app/src/main/java/net/typeblog/shelter/ui/AppListAdapter.java
@@ -29,16 +29,14 @@ import java.util.stream.Collectors;
 
 public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHolder> {
     class ViewHolder extends RecyclerView.ViewHolder {
-        private ViewGroup mView;
         private ImageView mIcon;
         private TextView mTitle;
         private TextView mPackage;
         // This text view shows the order of all selected items
         private TextView mSelectOrder;
         int mIndex = -1;
-        ViewHolder(ViewGroup view) {
+        ViewHolder(View view) {
             super(view);
-            mView = view;
             mIcon = view.findViewById(R.id.list_app_icon);
             mTitle = view.findViewById(R.id.list_app_title);
             mPackage = view.findViewById(R.id.list_app_package);
@@ -57,7 +55,7 @@ public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHold
                 // pass the full info to it, since we can't be sure
                 // the index won't change
                 if (mContextMenuHandler != null) {
-                    mContextMenuHandler.showContextMenu(mList.get(mIndex), mView);
+                    mContextMenuHandler.showContextMenu(mList.get(mIndex), itemView);
                 }
             } else {
                 // In multi-select mode, single clicks just adds to the selection
@@ -91,7 +89,7 @@ public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHold
         void select() {
             mSelectedIndices.add(mIndex);
             mSelectOrder.clearAnimation();
-            mSelectOrder.startAnimation(AnimationUtils.loadAnimation(mView.getContext(), R.anim.scale_appear));
+            mSelectOrder.startAnimation(AnimationUtils.loadAnimation(itemView.getContext(), R.anim.scale_appear));
             showSelectOrder();
         }
 
@@ -100,7 +98,7 @@ public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHold
             mSelectedIndices.remove((Integer) mIndex);
             mSelectOrder.clearAnimation();
             setUnselectedBackground();
-            Animation anim = AnimationUtils.loadAnimation(mView.getContext(), R.anim.scale_hide);
+            Animation anim = AnimationUtils.loadAnimation(itemView.getContext(), R.anim.scale_hide);
             anim.setAnimationListener(new Animation.AnimationListener() {
                 @Override
                 public void onAnimationStart(Animation animation) {
@@ -132,11 +130,11 @@ public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHold
         // (not necessarily when the user clicked on it; the view might have been recycled)
         void showSelectOrder() {
             if (!mList.get(mIndex).isHidden()) {
-                mView.setBackgroundResource(R.color.selectedAppBackground);
+                itemView.setBackgroundResource(R.color.selectedAppBackground);
             } else {
                 // The app is both frozen and selected
                 // we use a blended color of the two for its background
-                mView.setBackgroundResource(R.color.selectedAndDisabledAppBackground);
+                itemView.setBackgroundResource(R.color.selectedAndDisabledAppBackground);
             }
             mSelectOrder.setVisibility(View.VISIBLE);
             mSelectOrder.setText(String.valueOf(mSelectedIndices.indexOf(mIndex) + 1));
@@ -151,9 +149,9 @@ public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHold
         // Set the background when not in the selected state
         void setUnselectedBackground() {
             if (!mList.get(mIndex).isHidden()) {
-                mView.setBackground(null);
+                itemView.setBackground(null);
             } else {
-                mView.setBackgroundResource(R.color.disabledAppBackground);
+                itemView.setBackgroundResource(R.color.disabledAppBackground);
             }
         }
 
@@ -328,7 +326,7 @@ public class AppListAdapter extends RecyclerView.Adapter<AppListAdapter.ViewHold
             mLabelDisabled = viewGroup.getContext().getString(R.string.list_item_disabled);
         }
         LayoutInflater inflater = viewGroup.getContext().getSystemService(LayoutInflater.class);
-        ViewGroup view = (ViewGroup) inflater.inflate(R.layout.app_list_item, viewGroup, false);
+        View view = inflater.inflate(R.layout.app_list_item, viewGroup, false);
         ViewHolder vh = new ViewHolder(view);
         vh.setIndex(i);
         return vh;

--- a/app/src/main/java/net/typeblog/shelter/ui/AppListFragment.java
+++ b/app/src/main/java/net/typeblog/shelter/ui/AppListFragment.java
@@ -98,7 +98,7 @@ public class AppListFragment extends BaseFragment {
         @Override
         public void onReceive(Context context, Intent intent) {
             String query = intent.getStringExtra("text");
-            if (query == "") {
+            if ("".equals(query)) {
                 // Consider empty query as null
                 query = null;
             }

--- a/app/src/main/java/net/typeblog/shelter/util/CrossProfileDocumentsProvider.java
+++ b/app/src/main/java/net/typeblog/shelter/util/CrossProfileDocumentsProvider.java
@@ -50,7 +50,7 @@ public class CrossProfileDocumentsProvider extends DocumentsProvider {
     // We just release the service when idle, thus enabling the
     // system to release memory
     private Runnable mReleaseServiceTask = this::releaseService;
-    private Object mLock = new Object();
+    private final Object mLock = new Object();
 
     private void doBindService() {
         // Call DummyActivity on the other side to bind the service for us

--- a/app/src/main/java/net/typeblog/shelter/util/CrossProfileDocumentsProvider.java
+++ b/app/src/main/java/net/typeblog/shelter/util/CrossProfileDocumentsProvider.java
@@ -137,7 +137,7 @@ public class CrossProfileDocumentsProvider extends DocumentsProvider {
     public Cursor queryDocument(String documentId, String[] projection) {
         ensureServiceBound();
         final MatrixCursor result = new MatrixCursor(projection == null ? DEFAULT_DOCUMENT_PROJECTION : projection);
-        Map<String, Object> fileInfo = null;
+        Map<String, Object> fileInfo;
         try {
             fileInfo = mService.loadFileMeta(documentId);
         } catch (RemoteException e) {
@@ -150,7 +150,7 @@ public class CrossProfileDocumentsProvider extends DocumentsProvider {
     @Override
     public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder) {
         ensureServiceBound();
-        List<Map<String, Object>> files = null;
+        List<Map<String, Object>> files;
         try {
             files = mService.loadFiles(parentDocumentId);
         } catch (RemoteException e) {

--- a/app/src/main/java/net/typeblog/shelter/util/CrossProfileDocumentsProvider.java
+++ b/app/src/main/java/net/typeblog/shelter/util/CrossProfileDocumentsProvider.java
@@ -22,6 +22,7 @@ import net.typeblog.shelter.services.IFileShuttleService;
 import net.typeblog.shelter.services.IFileShuttleServiceCallback;
 import net.typeblog.shelter.ui.DummyActivity;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -137,7 +138,7 @@ public class CrossProfileDocumentsProvider extends DocumentsProvider {
     public Cursor queryDocument(String documentId, String[] projection) {
         ensureServiceBound();
         final MatrixCursor result = new MatrixCursor(projection == null ? DEFAULT_DOCUMENT_PROJECTION : projection);
-        Map<String, Object> fileInfo;
+        Map<String, Serializable> fileInfo;
         try {
             fileInfo = mService.loadFileMeta(documentId);
         } catch (RemoteException e) {
@@ -150,7 +151,7 @@ public class CrossProfileDocumentsProvider extends DocumentsProvider {
     @Override
     public Cursor queryChildDocuments(String parentDocumentId, String[] projection, String sortOrder) {
         ensureServiceBound();
-        List<Map<String, Object>> files;
+        List<Map<String, Serializable>> files;
         try {
             files = mService.loadFiles(parentDocumentId);
         } catch (RemoteException e) {
@@ -161,7 +162,7 @@ public class CrossProfileDocumentsProvider extends DocumentsProvider {
         result.setNotificationUri(getContext().getContentResolver(),
                 DocumentsContract.buildDocumentUri(AUTHORITY, parentDocumentId));
 
-        for (Map<String, Object> file : files) {
+        for (Map<String, Serializable> file : files) {
             includeFile(result, file);
         }
         return result;
@@ -223,7 +224,7 @@ public class CrossProfileDocumentsProvider extends DocumentsProvider {
         }
     }
 
-    private void includeFile(MatrixCursor cursor, Map<String, Object> fileInfo) {
+    private void includeFile(MatrixCursor cursor, Map<String, Serializable> fileInfo) {
         final MatrixCursor.RowBuilder row = cursor.newRow();
         for (String col : DEFAULT_DOCUMENT_PROJECTION) {
             row.add(col, fileInfo.get(col));

--- a/app/src/main/java/net/typeblog/shelter/util/Utility.java
+++ b/app/src/main/java/net/typeblog/shelter/util/Utility.java
@@ -353,7 +353,7 @@ public class Utility {
     public static String getFileExtension(String filePath) {
         int index = filePath.lastIndexOf(".");
         if (index > 0) {
-            return filePath.substring(index + 1, filePath.length());
+            return filePath.substring(index + 1);
         } else {
             return null;
         }


### PR DESCRIPTION
Here are just a few fixes and code cleaning that do not alter the behavior of the current codebase:
- make use of the recycler view holder's `itemView`field
- retrieve layout inflater from our context rather than system service
- use `final` modifier for constants and lock objects
- remove redundant stuff
- disambiguate generic types in AIDL (all objects in maps and lists are actually `Serializable`)
- fix string equality (also made `null`-proof)