### PR TITLE
Add functionality: install ca cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Features
 ===
 
 - Installing apps inside a work profile for isolation
+- Installing CA certificates inside a work profile
 - "Freeze" apps inside the work profile to prevent them from running or being woken up when you are not actively using them
 - Installing two copies of the same app on the same device
 

--- a/app/src/main/aidl/net/typeblog/shelter/services/IShelterService.aidl
+++ b/app/src/main/aidl/net/typeblog/shelter/services/IShelterService.aidl
@@ -17,6 +17,7 @@ interface IShelterService {
     void loadIcon(in ApplicationInfoWrapper info, ILoadIconCallback callback);
     void installApp(in ApplicationInfoWrapper app, IAppInstallCallback callback);
     void installApk(in UriForwardProxy uri, IAppInstallCallback callback);
+    void installCaCert(in UriForwardProxy uri, IAppInstallCallback callback);
     void uninstallApp(in ApplicationInfoWrapper app, IAppInstallCallback callback);
     void freezeApp(in ApplicationInfoWrapper app);
     void unfreezeApp(in ApplicationInfoWrapper app);

--- a/app/src/main/res/menu/main_activity_menu.xml
+++ b/app/src/main/res/menu/main_activity_menu.xml
@@ -29,6 +29,10 @@
         android:title="@string/install_app_to_profile" />
 
     <item
+        android:id="@+id/main_menu_install_ca_cert"
+        android:title="@string/install_ca_cert_to_profile" />
+
+    <item
         android:id="@+id/main_menu_documents_ui"
         android:title="@string/documents_ui" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,9 @@
     <string name="freeze_all_shortcut">Freeze</string>
     <string name="install_app_to_profile">Install APK into Shelter</string>
     <string name="install_app_to_profile_success">Application installation finished in work profile.</string>
+    <string name="install_ca_cert_to_profile">Install CA certificate into Shelter</string>
+    <string name="install_ca_cert_to_profile_success">CA certificate successfully installed in work profile.</string>
+    <string name="install_ca_cert_to_profile_failure">Failed to install CA certificate in work profile.</string>
     <string name="show_all">Show All Apps</string>
     <string name="show_all_warning">Manipulating apps that are hidden from the list could cause crashes and all sorts of unexpected behavior. However, this feature can be useful when faulty vendor-customized ROMs does not enable all necessary system apps in work profile by default. If you continue, you are on your own.</string>
     <string name="documents_ui">Open Documents UI</string>


### PR DESCRIPTION
This pull request implements a simple functionality: install a ca cert in the work profile.
You'd need a CA certificate e.g. for MS Exchange account connection in Gmail app, or other https connection verification (e.g. Mattermost app), etc.